### PR TITLE
Add ability to specify a custom response transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ pub async fn error_test() -> Result<HttpResponse, Error> {
 The `reason` is a string that may be given to the client in some form to explain
 the error, if appropriate. Here it is as an enum that can be localized.
 
-**Note:** This response has been formatted by a [`ResponseTransform`][response_transform].
+**Note:** This response has been formatted by a [`ResponseTransform`][response_transform]. To specify a custom ResponseTransform, implement [`ResponseTransform`][response_transform] and add `#[response(transform = custom)]` under your derive.
 
 ```
 {

--- a/actix-web-thiserror-derive/Cargo.toml
+++ b/actix-web-thiserror-derive/Cargo.toml
@@ -20,4 +20,4 @@ http = "0.2.9"
 lazy_static = "1.4.0"
 proc-macro2 = "1.0.56"
 quote = "1.0.26"
-syn = { version = "1.0.107", features = ["extra-traits"] }
+syn = { version = "1.0.107", features = ["full"] }

--- a/actix-web-thiserror-derive/src/response_error.rs
+++ b/actix-web-thiserror-derive/src/response_error.rs
@@ -2,9 +2,10 @@ use std::collections::{HashMap, HashSet};
 use std::iter::Peekable;
 
 use proc_macro::TokenStream;
-use proc_macro2::{token_stream::IntoIter, TokenTree};
+use proc_macro2::{TokenTree, token_stream::IntoIter};
 use quote::quote;
 use syn::DeriveInput;
+use syn::parse::Parser;
 
 pub fn derive_response_error(input: TokenStream) -> TokenStream {
   let ast = syn::parse_macro_input!(input as DeriveInput);
@@ -168,6 +169,39 @@ pub fn derive_response_error(input: TokenStream) -> TokenStream {
     }
   };
 
+  let transform = ast.attrs
+    .into_iter()
+    .find_map(|x| {
+      if !(x.path.segments.len() == 1 && x.path.segments.first()?.ident == "response") {
+        return None;
+      }
+
+      let proc_macro2::TokenTree::Group(group) = x.tokens.into_iter().next()? else { return None; };
+      let ident_assigns = syn::punctuated::Punctuated::<syn::ExprAssign, syn::Token![,]>::parse_terminated
+        .parse(group.stream().into())
+        .unwrap()
+        .into_iter()
+        .filter_map(|x| {
+          let syn::Expr::Path(syn::ExprPath {path, ..}) = *x.left else { return None; };
+          let left = path.get_ident()?;
+          
+          let syn::Expr::Path(syn::ExprPath {path, ..}) = *x.right else { return None; };
+          let right = path.get_ident()?;
+          
+          Some((left.to_string(), right.to_string()))
+        })
+        .collect::<HashMap<String, String>>();
+
+      if ident_assigns.get("transform")? == "custom" {
+        return Some(quote! { self.transform })
+      }
+
+      // could add additional to check for invalid options?
+
+      None
+    })
+    .unwrap_or(quote! { actix_web_thiserror::apply_global_transform });
+
   let expanded = quote! {
     impl ::actix_web_thiserror::ThiserrorResponse for #name {
       fn status_code(&self) -> Option<http::StatusCode> {
@@ -209,7 +243,7 @@ pub fn derive_response_error(input: TokenStream) -> TokenStream {
 
         error!("Response error: {err}\n\t{name}({err:?})", name = #name_str, err = &self);
 
-        actix_web_thiserror::apply_global_transform(
+        #transform(
           #name_str,
           &self,
           self.status_code(),


### PR DESCRIPTION
#6 

By adding `#[response(transform = custom)]`, it will use the custom implementation instead. Note that `custom` does not represent the function name but just indicates to do `self.transform` instead.