### PR TITLE
Avoid direct http crate dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "actix-web-thiserror",
   "actix-web-thiserror-derive",

--- a/actix-web-thiserror-derive/Cargo.toml
+++ b/actix-web-thiserror-derive/Cargo.toml
@@ -15,8 +15,8 @@ name = "actix_web_thiserror_derive"
 proc-macro = true
 
 [dependencies]
+actix-web = "4.3.1"
 arc-swap = "1.6.0"
-http = "0.2.9"
 lazy_static = "1.4.0"
 proc-macro2 = "1.0.56"
 quote = "1.0.26"

--- a/actix-web-thiserror-derive/src/response_error.rs
+++ b/actix-web-thiserror-derive/src/response_error.rs
@@ -204,7 +204,7 @@ pub fn derive_response_error(input: TokenStream) -> TokenStream {
 
   let expanded = quote! {
     impl ::actix_web_thiserror::ThiserrorResponse for #name {
-      fn status_code(&self) -> Option<http::StatusCode> {
+      fn status_code(&self) -> Option<actix_web::http::StatusCode> {
         match self {
           #status_code_match
           _ => None,
@@ -220,7 +220,7 @@ pub fn derive_response_error(input: TokenStream) -> TokenStream {
     }
 
     impl actix_web::error::ResponseError for #name {
-      fn status_code(&self) -> http::StatusCode {
+      fn status_code(&self) -> actix_web::http::StatusCode {
         match ::actix_web_thiserror::ThiserrorResponse::status_code(self) {
           Some(status_code) => status_code,
           _ => {
@@ -311,7 +311,7 @@ fn get_status_code_literal(tokens: &mut Peekable<IntoIter>) -> Option<proc_macro
         .to_string()
         .parse::<u16>()
         .ok()
-        .and_then(|status| http::StatusCode::from_u16(status).ok())
+        .and_then(|status| actix_web::http::StatusCode::from_u16(status).ok())
         .is_none()
       {
         panic!("invalid status code");
@@ -345,7 +345,7 @@ fn get_status_code(tokens: &mut Peekable<IntoIter>) -> Option<proc_macro2::Token
 
     Some(TokenTree::Literal(_)) => get_status_code_literal(tokens).map(|tokens| {
       quote! {
-        http::StatusCode::from_u16(#tokens as u16)
+        actix_web::http::StatusCode::from_u16(#tokens as u16)
           .unwrap_or_else(|_| unreachable!())
       }
     }),

--- a/actix-web-thiserror/Cargo.toml
+++ b/actix-web-thiserror/Cargo.toml
@@ -15,7 +15,6 @@ documentation = "https://docs.rs/actix-web-thiserror"
 actix-web = "4.3.1"
 actix-web-thiserror-derive = { version = "0.2.0", path = "../actix-web-thiserror-derive" }
 arc-swap = "1.6.0"
-http = "0.2.9"
 lazy_static = "1.4.0"
 serde_json = "1.0.96"
 

--- a/actix-web-thiserror/src/lib.rs
+++ b/actix-web-thiserror/src/lib.rs
@@ -92,14 +92,14 @@ pub trait ResponseTransform {
     &self,
     name: &str,
     err: &dyn std::error::Error,
-    status_code: http::StatusCode,
+    status_code: actix_web::http::StatusCode,
     reason: Option<serde_json::Value>,
   ) -> HttpResponse {
     actix_web::HttpResponse::build(status_code).finish()
   }
 
-  fn default_error_status_code(&self) -> http::StatusCode {
-    http::StatusCode::INTERNAL_SERVER_ERROR
+  fn default_error_status_code(&self) -> actix_web::http::StatusCode {
+    actix_web::http::StatusCode::INTERNAL_SERVER_ERROR
   }
 }
 
@@ -121,7 +121,7 @@ pub fn set_global_transform(transform: impl ResponseTransform + Sync + Send + 's
 pub fn apply_global_transform(
   name: &str,
   err: &dyn std::error::Error,
-  status_code: http::StatusCode,
+  status_code: actix_web::http::StatusCode,
   reason: Option<serde_json::Value>,
 ) -> HttpResponse {
   ResponseTransform::transform(
@@ -134,13 +134,13 @@ pub fn apply_global_transform(
 }
 
 #[doc(hidden)]
-pub fn default_global_error_status_code() -> http::StatusCode {
+pub fn default_global_error_status_code() -> actix_web::http::StatusCode {
   ResponseTransform::default_error_status_code((&**RESPONSE_TRANSFORM.load()).as_ref())
 }
 
 #[doc(hidden)]
 pub trait ThiserrorResponse {
-  fn status_code(&self) -> Option<http::StatusCode> {
+  fn status_code(&self) -> Option<actix_web::http::StatusCode> {
     None
   }
 


### PR DESCRIPTION
Currently crates using `actix-web-thiserror` need to add `http = ..` into their Cargo.toml.

This PR removes that requirement.

This is one aspect of https://github.com/enzious/actix-web-thiserror/issues/5