### PR TITLE
chore: remove logging, let user define behavior

### DIFF
--- a/actix-web-thiserror-derive/src/response_error.rs
+++ b/actix-web-thiserror-derive/src/response_error.rs
@@ -346,8 +346,6 @@ pub fn derive_response_error(input: TokenStream) -> TokenStream {
           }
             .and_then(|value| value));
 
-        log::error!("Response error: {err}\n\t{name}({err:?})", name = #name_str, err = &self);
-
         #transform(
           #name_str,
           &self,

--- a/actix-web-thiserror/Cargo.toml
+++ b/actix-web-thiserror/Cargo.toml
@@ -19,6 +19,5 @@ lazy_static = "1.4.0"
 serde_json = "1.0.96"
 
 [dev-dependencies]
-log = "0.4.17"
-thiserror = "1.0.40"
+thiserror = "2.0.16"
 trybuild = "1.0"

--- a/actix-web-thiserror/src/lib.rs
+++ b/actix-web-thiserror/src/lib.rs
@@ -62,12 +62,26 @@
 //!
 //! ## Error logging
 //!
-//! The error text automatically prints to the log when the error is returned out
-//! through a http response.
+//! Error logging should be done in the [`ResponseTransform::transform`][ResponseTransform::transform] method.
 //!
-//! ```text
-//! Apr 23 02:19:35.211 ERROR Response error: invalid image format
-//!     Base64ImageError(InvalidImageFormat), place: example/src/handler.rs:5 example::handler
+//! ```ignore
+//! fn transform(
+//!   &self,
+//!   name: &str,
+//!   err: &dyn std::error::Error,
+//!   status_code: actix_web::http::StatusCode,
+//!   reason: Option<serde_json::Value>,
+//!   _type: Option<String>,
+//!   details: Option<serde_json::Value>,
+//! ) -> HttpResponse {
+//!   if let Some(backtrace) = request_ref::<std::backtrace::Backtrace>(&err) {
+//!     log::error!("Response error: {err}\n{name}\n{backtrace}");
+//!   } else {
+//!     log::error!("Response error: {err}\n{name}");
+//!   }
+//!
+//!   HttpResponse::InternalServerError().finish()
+//! }
 //! ```
 //!
 //! [thiserror]: https://docs.rs/thiserror


### PR DESCRIPTION
I wanna add backtraces for my error logging.
I already had logging in the library.

Solution: Remove logging in the library.

Maybe backwards-compatibility or usability are important, should we add it to the default implementation?

Thoughts?